### PR TITLE
ブラウザバック・フォワード次にiframe部分が表示できなくなる問題の修正

### DIFF
--- a/nuxt/app/pages/slide-view/[slideId]/index.vue
+++ b/nuxt/app/pages/slide-view/[slideId]/index.vue
@@ -2,6 +2,7 @@
 const route = useRoute()
 
 const slideUrl = computed(() => {
+  if (!route.params.slideId) return undefined
   return `/slides/${route.params.slideId}/`
 })
 </script>
@@ -9,6 +10,8 @@ const slideUrl = computed(() => {
 <template>
   <div>
     <iframe
+      v-if="slideUrl"
+      :key="slideUrl"
       :src="slideUrl"
       style="width:100%;height:100vh;border:none"
     />

--- a/slides/slides/why-choose-sapporo/slides.md
+++ b/slides/slides/why-choose-sapporo/slides.md
@@ -9,6 +9,7 @@ drawings:
 transition: slide-left
 mdc: true
 duration: 35min
+routerMode: hash
 ---
 
 # **田舎から札幌に移住して半年**


### PR DESCRIPTION
## やったこと
- スライドのrouterModeをhashに変更
- route.paramsがなかった場合の対応を追加
- https://github.com/Shade4827/slides/issues/12