### PR TITLE
CI上でslidevのビルドを行いコミットするように変更

### DIFF
--- a/.github/workflows/build-slides.yaml
+++ b/.github/workflows/build-slides.yaml
@@ -1,0 +1,37 @@
+name: Build Slides
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'nuxt/public/slides/**'
+      - 'nuxt/public/slides.json'
+
+jobs:
+  build-slides:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - run: pnpm install
+      - run: pnpm exec playwright install --with-deps
+      - run: pnpm build:slides
+
+      - name: Commit generated files
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add nuxt/public/slides
+          git add nuxt/public/slides.json
+          git commit -m "chore: update slides assets" || echo "No changes"
+          git push

--- a/nuxt/.gitignore
+++ b/nuxt/.gitignore
@@ -22,6 +22,3 @@ logs
 .env
 .env.*
 !.env.example
-
-public/slides
-slides.json

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build:slides": "node scripts/build-slides.mjs",
-    "build": "pnpm build:slides && pnpm --filter nuxt build"
+    "build": "pnpm --filter nuxt build"
   },
   "devDependencies": {
     "@slidev/cli": "^52.14.1",


### PR DESCRIPTION
## やったこと
- Cloudflare Pagesのデプロイ時にplaywrightのブラウザをインストールすることができないため、GitHub Actions上でslidevのビルドをするように変更
- ビルドの成果物をコミットしてリポジトリ上に保存